### PR TITLE
chore(client): upgrade eslint to ^9.36.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/node": "24.3.1",
     "@types/react": "19.1.12",
-    "eslint": "^8.56.0",
+  "eslint": "^9.36.0",
     "eslint-config-next": "^15.5.3"
   }
 }


### PR DESCRIPTION
Upgrade devDependency eslint to v9 to remove deprecated transitive deps and keep linting up to date. Runs cleanly locally (client build and server tests pass).